### PR TITLE
Update md depend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # Ignore bundler config.
 /.bundle
 
+# Local gems
+vendor/
+
 # Ignore the default SQLite database.
 /db/*.sqlite3
 /db/*.sqlite3-journal
@@ -30,3 +33,6 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+# mac system files
+.DS_STORE

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,9 @@ gem 'puma', '~> 4.1'
 # downgrade psych in response to https://stackoverflow.com/questions/68802089/rails-couldnt-infer-whether-you-are-using-multiple-databases-from-your-database
 gem 'psych', '< 4.0.0'
 
-gem 'adiwg-mdtranslator', '~> 2.18'
+gem 'adiwg-mdtranslator',
+    git: 'https://github.com/GSA/mdTranslator.git',
+    branch: 'feature/DCAT-US-v1'
 
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'

--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'psych', '< 4.0.0'
 
 gem 'adiwg-mdtranslator',
     git: 'https://github.com/GSA/mdTranslator.git',
-    branch: 'feature/DCAT-US-v1'
+    branch: 'datagov'
 
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/GSA/mdTranslator.git
-  revision: 9b4540f1433261761ff04814fe9d777e2fa55ca9
-  branch: feature/DCAT-US-v1
+  revision: fe10f1d66171757f87be54e3053e0c09821500b4
+  branch: datagov
   specs:
     adiwg-mdtranslator (2.20.0.pre.beta.5)
       adiwg-mdcodes (= 2.10.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,21 @@
+GIT
+  remote: https://github.com/GSA/mdTranslator.git
+  revision: 9b4540f1433261761ff04814fe9d777e2fa55ca9
+  branch: feature/DCAT-US-v1
+  specs:
+    adiwg-mdtranslator (2.20.0.pre.beta.5)
+      adiwg-mdcodes (= 2.10.0)
+      adiwg-mdjson_schemas (= 2.9.5)
+      builder (~> 3.2)
+      coderay (~> 1.1)
+      jbuilder (~> 2.5)
+      json (~> 2.0)
+      json-schema (~> 2.7)
+      kramdown (>= 1.13, < 3.0)
+      nokogiri (~> 1.15)
+      thor (~> 0.19)
+      uuidtools (~> 2.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -58,21 +76,9 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
-    adiwg-mdcodes (2.8.4)
+    adiwg-mdcodes (2.10.0)
       json (~> 2.0)
-    adiwg-mdjson_schemas (2.8.1)
-    adiwg-mdtranslator (2.18.4)
-      adiwg-mdcodes (= 2.8.4)
-      adiwg-mdjson_schemas (= 2.8.1)
-      builder (~> 3.2)
-      coderay (~> 1.1)
-      jbuilder (~> 2.5)
-      json (~> 2.0)
-      json-schema (~> 2.7)
-      kramdown (>= 1.13, < 3.0)
-      nokogiri (~> 1.7)
-      thor (~> 0.19)
-      uuidtools (~> 2.1)
+    adiwg-mdjson_schemas (2.9.5)
     ast (2.4.2)
     bootsnap (1.17.0)
       msgpack (~> 1.2)
@@ -88,7 +94,7 @@ GEM
       activesupport (>= 5.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    jbuilder (2.11.5)
+    jbuilder (2.12.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.7.1)
@@ -133,7 +139,7 @@ GEM
       racc
     prettier_print (1.2.1)
     psych (3.3.4)
-    public_suffix (5.0.4)
+    public_suffix (5.0.5)
     puma (4.3.12)
       nio4r (~> 2.0)
     racc (1.7.3)
@@ -226,7 +232,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  adiwg-mdtranslator (~> 2.18)
+  adiwg-mdtranslator!
   bootsnap (>= 1.4.2)
   byebug
   listen (~> 3.2)


### PR DESCRIPTION
related to [#4796](https://github.com/GSA/data.gov/issues/4796)

- datagov fork is up-to-date with upstream
- merged dcatus-v1 branch into datagov branch
- mdtranslator gem points to datagov branch 
- ci/cd in place. app deployed in development.
```terminal
Showing health and status for app mdtranslator in org gsa-datagov / space development as reid.hewitt@gsa.gov...

name:              mdtranslator
requested state:   started
routes:            mdtranslator.app.cloud.gov
last uploaded:     Wed 19 Jun 09:52:44 MDT 2024
stack:             cflinuxfs4
buildpacks:        
        name             version   detect output   buildpack name
        ruby_buildpack   1.10.15   ruby            ruby

type:           web
sidecars:       
instances:      1/1
memory usage:   128M
     state     since                  cpu    memory          disk         logging               details
#0   running   2024-06-19T15:53:01Z   0.4%   93.9M of 128M   234M of 1G   304B/s of unlimited  
```