### PR TITLE
minor fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,10 @@ gem 'adiwg-mdtranslator',
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false
 
+# fix
+# https://stackoverflow.com/questions/79360526/uninitialized-constant-activesupportloggerthreadsafelevellogger-nameerror
+gem 'concurrent-ruby', '1.3.4'
+
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/GSA/mdTranslator.git
-  revision: 95b5c77ed64700e21c2cf0fc48158c9259eba8cf
+  revision: d2b48a009e2fe92dd3b0ce99e84dc716601d127c
   branch: master
   specs:
     adiwg-mdtranslator (2.20.0.pre.beta.5)
@@ -268,6 +268,7 @@ DEPENDENCIES
   adiwg-mdtranslator!
   bootsnap (>= 1.4.2)
   byebug
+  concurrent-ruby (= 1.3.4)
   listen (~> 3.2)
   newrelic_rpm (~> 9.16)
   psych (< 4.0.0)

--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,14 @@ build: ## Build the app image
 	docker build -t datagov/mdtranslator . 
 
 start:
-	rails server -b 0.0.0.0 -p 3000
+	bundle exec rails server -b 0.0.0.0 -p 3000
 
 lint:
 	bundle exec rubocop
 
 .PHONY: test
 test:
-	rails test
+	bundle exec rails test
 
 # recursively finds all .rb files in the current dir and formats them using stree
 format:

--- a/app/controllers/translates_controller.rb
+++ b/app/controllers/translates_controller.rb
@@ -102,6 +102,10 @@ class TranslatesController < ApplicationController
     @response_info[:success] = false unless @md_return[:readerExecutionPass]
     @response_info[:success] = false unless @md_return[:writerPass]
 
+    # execution status doesn't prevent writing in mdtranslator so correcting here
+    @response_info[:success] = false unless @response_info[:readerExecutionStatus] == 'OK'
+    @response_info[:writerOutput] = nil unless @response_info[:readerExecutionStatus] == 'OK'
+
     render json: @response_info, status: @response_info[:success] ? 200 : 422
   end
 end


### PR DESCRIPTION
related to [#4565](https://github.com/GSA/data.gov/issues/4565)

- fix local setup issues
  - use bundle to run rails ( otherwise you'd need that installed globally )
  - bug with concurrent ruby so pinning to version. prevents rails server from starting.
- add safeguard against reader execution messages
  - fgdc reader produces execution messages. even though we're probably not going to support that standard adding the check is for peace of mind.
- update lock with latest mdt commit